### PR TITLE
Update documentation for Authentication

### DIFF
--- a/source/includes/authentication/_index.md.erb
+++ b/source/includes/authentication/_index.md.erb
@@ -1,31 +1,62 @@
 # Authentication
 
-> To authorize, use this code:
+Access to resources in the Tuition.io API requires a valid API Key and an authentication token.
 
-```shell
-## Login
-curl -X "POST" "http://localhost:3000/login" \
-     -H 'Content-Type: application/json' \
-     -d $'{
-  "user": {
-    "email": "cory+super_admin@me.com",
-    "password": "Test1234!"
-  }
-}'
+Tuition.io expects your unique, public API key to be included in the `x-api-key` request header:
+
+`x-api-key: API_KEY`
+
+To authenticate requests, the Tuition.io API expects an authentication token to be sent in the `tio-auth-token` request header:
+
+`tio-auth-token: eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw`
+
+The authentication token is a JWT encoded with the `HS512` algorithm and "signed" with the "secret" component of your API Key.
+
+For example, Tuition.io provides you with the following API Key details:
+
+```json
+{
+  "key": "xNTE2MjM5MDI",
+  "secret": "purrrrrfectt"
+}
 ```
 
-> Make sure to replace `<%= config[:api_key] %>` with your API key.  
-> Make sure to replace `purrrrrfectt` with your authentication token.
+Using the JWT gem for Ruby, you would build your own authentication token with code like this:
 
-Tuition.io uses API keys to allow access to the API coupled with an authorization token.
+```ruby
+claims = {
+  iat: 1609883853, # The time the JWT was computed in seconds since epoch (1609883853 => January 5, 2021 9:57:33 PM) [required]
+  exp: 1609887476, # The time this JWT expires in seconds since epoch (1609887476 => January 5, 2021 10:57:56 PM) [required]
+  iss: 'Example Company, LLC' # Something to identify you as the issuer of the token [optional]
+}
 
-Tuition.io expects for the API key to be included in all API requests to the server in a header that looks like the following:
+token = JWT.encode(claims, 'purrrrrfectt', 'HS512')
+```
 
-`x-api-key: <%= config[:api_key] %>`  
-`tio-auth-token: purrrrrfectt`
+> Make sure to replace `purrrrrfectt` with your API Key secret.
+
+## JWT Claims
+
+Currently, the only required JWT claims are the "issued at" and "expiration" time stamps: `iat` and `exp`.
+
+### Issued at / iat
+
+The time the JWT was computed in seconds since epoch. The Tuition.io API does not allow JWTs older than 1 year of age or issued in the future. Setting `iat` to the current timestamp should work in most cases.
+
+### Expiration / exp
+
+The time the JWT will expire. The Tuition.io API will reject requests with expired JWTs. For security, we recommend JWTs that expire after a few minutes. But the API allows JWTs up to 1 year old.
+
+## Example Request
+
+```shell
+curl -X GET "<%= config[:base_url] %>/employees" \
+    -H "x-api-key: xNTE2MjM5MDI" \
+    -H "tio-auth-token: eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw"
+```
 
 <aside class="notice">
   <br>
-  You must replace <code><%= config[:api_key] %></code> with your API key.<br>
-  You must replace <code>purrrrrfectt</code> with your authentication token.
+  You must replace <code>xNTE2MjM5MDI</code> with your API key.<br>
+  You must replace <code>purrrrrfectt</code> with your API Key secret.
 </aside>


### PR DESCRIPTION
Change Authentication documentation:

* Remove mention of `/login` endpoint
* Explain how to build a JWT
* Example headers in Tuition.io requests



# Authentication

Access to resources in the Tuition.io API requires a valid API Key and an authentication token.

Tuition.io expects your unique, public API key to be included in the `x-api-key` request header:

`x-api-key: API_KEY`

To authenticate requests, the Tuition.io API expects an authentication token to be sent in the `tio-auth-token` request header:

`tio-auth-token: eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw`

The authentication token is a JWT encoded with the `HS512` algorithm and "signed" with the "secret" component of your API Key.

For example, Tuition.io provides you with the following API Key details:

```json
{
  "key": "xNTE2MjM5MDI",
  "secret": "purrrrrfectt"
}
```

Using the JWT gem for Ruby, you would build your own authentication token with code like this:

```ruby
claims = {
  iat: 1609883853, # The time the JWT was computed in seconds since epoch (1609883853 => January 5, 2021 9:57:33 PM) [required]
  exp: 1609887476, # The time this JWT expires in seconds since epoch (1609887476 => January 5, 2021 10:57:56 PM) [required]
  iss: 'Example Company, LLC' # Something to identify you as the issuer of the token [optional]
}

token = JWT.encode(claims, 'purrrrrfectt', 'HS512')
```

> Make sure to replace `purrrrrfectt` with your API Key secret.

## JWT Claims

Currently, the only required JWT claims are the "issued at" and "expiration" time stamps: `iat` and `exp`.

### Issued at / iat

The time the JWT was computed in seconds since epoch. The Tuition.io API does not allow JWTs older than 1 year of age or issued in the future. Setting `iat` to the current timestamp should work in most cases.

### Expiration / exp

The time the JWT will expire. The Tuition.io API will reject requests with expired JWTs. For security, we recommend JWTs that expire after a few minutes. But the API allows JWTs up to 1 year old.

## Example Request

```shell
curl -X GET "<%= config[:base_url] %>/employees" \
    -H "x-api-key: xNTE2MjM5MDI" \
    -H "tio-auth-token: eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw"
```

<aside class="notice">
  <br>
  You must replace <code>xNTE2MjM5MDI</code> with your API key.<br>
  You must replace <code>purrrrrfectt</code> with your API Key secret.
</aside>
