### PR TITLE
Add docs for Companies, JSONAPI. Refactor authentication docs.

### DIFF
--- a/config.rb
+++ b/config.rb
@@ -43,7 +43,10 @@ set :relative_links, true
 set :api_key, 'meowmeowmeow'
 config[:api_key]
 
-set :api_token, 'purrrrrfectt'
+set :api_secret, 'purrrrrfectt'
+config[:api_secret]
+
+set :api_token, 'eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw'
 config[:api_token]
 
 set :base_url, 'https://localhost:3030'

--- a/source/includes/authentication/_errors.md.erb
+++ b/source/includes/authentication/_errors.md.erb
@@ -1,0 +1,12 @@
+## Authentication Errors
+
+The Tuition.io API will report the following errors when there is a problem with the provided API Key or authentication token.
+
+Problem | Status | Message | Description
+------- | ----------- | ------- | ------------
+Invalid Signature | 403 | "Invalid JWT token. Make sure algorithm and JWT secret match." | The authentication token does not appear to be "signed" with the correct API Key secret.
+Issued At (`iat`) Invalid | 403 | 'The token does not have a valid "issued at" time.' | The token's `iat` timestamp is missing, more than 1 year in the past, or set in the future.
+Expired Token | 401 | "The token has expired." | The token's `exp` timestamp is missing or has passed.
+Wrong Encoding Algorithm | 403 | "Invalid JWT token. Make sure algorithm and JWT secret match." | The token should be encoded with `HS512`. Other encoding strategies will fail.
+Missing Token | 400 | "Missing Authentication Token" | The `tio-auth-token` was not set in the request headers.
+Missing / Invalid API Key | 400 | "Invalid API Key" | The `x-api-key` header was not sent or contains an invalid / inactive value.

--- a/source/includes/authentication/_index.md.erb
+++ b/source/includes/authentication/_index.md.erb
@@ -4,39 +4,19 @@ Access to resources in the Tuition.io API requires a valid API Key and an authen
 
 Tuition.io expects your unique, public API key to be included in the `x-api-key` request header:
 
-`x-api-key: API_KEY`
+`x-api-key: <API_KEY>`
 
 To authenticate requests, the Tuition.io API expects an authentication token to be sent in the `tio-auth-token` request header:
 
-`tio-auth-token: eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw`
+`tio-auth-token: <%= config[:api_token] %>`
 
 ## Build Your Own Token
 
-```shell
-#!/usr/bin/env bash
-jwt_header=$(echo -n '{"alg":"HS512"}' | base64 | sed s/\+/-/g | sed 's/\//_/g' | sed -E s/=+$//)
-payload=$(echo -n '{"iat":1609883853,"exp":1609887476,"iss":"Example Company, LLC"}' | base64 | sed s/\+/-/g |sed 's/\//_/g' |  sed -E s/=+$//)
-secret='purrrrrfectt'
-hmac_signature=$(echo -n "${jwt_header}.${payload}" |  openssl sha512 -hmac "$secret" -binary | base64 | sed s/\+/-/g | sed 's/\//_/g' | sed -E s/=+$//)
-jwt="${jwt_header}.${payload}.${hmac_signature}"
-
-echo ${jwt}
-```
-
-```ruby
-# Using the Ruby JWT Gem: [https://github.com/jwt/ruby-jwt]
-
-claims = {
-  iat: 1609883853, # required
-  exp: 1609887476, # required
-  iss: 'Example Company, LLC' # optional
-}
-
-token = JWT.encode(claims, 'purrrrrfectt', 'HS512')
-```
+<%= partial "includes/authentication/examples/token/ruby.md.erb" %>
+<%= partial "includes/authentication/examples/token/shell.md.erb" %>
 
 > Note: These examples use fixed timestamps<br>
-> Make sure to replace `purrrrrfectt` with your API Key secret.
+> Make sure to replace `<%= config[:api_secret] %>` with your API Key secret.
 
 The authentication token is a [JWT](http://jwt.io) encoded with the `HS512` algorithm and "signed" with the "secret" component of your API Key.
 
@@ -44,8 +24,8 @@ For example, Tuition.io provides you with the following API Key details:
 
 Attribute Name | Value
 -------------- | -------------
-`key`          | `xNTE2MjM5MDI`
-`secret`       | `purrrrrfectt`
+`key`          | `<%= config[:api_key] %>`
+`secret`       | `<%= config[:api_secret] %>`
 
 You might build your own authentication token with the code shown here.
 
@@ -65,27 +45,14 @@ Parameter | Required | Description
 
 ```shell
 curl -X GET "<%= config[:base_url] %>/employees" \
-    -H "x-api-key: xNTE2MjM5MDI" \
-    -H "tio-auth-token: eyJhbGciOiJIUzUxMiJ9.eyJpYXQiOjE2MDk4ODM4NTMsImV4cCI6MTYwOTg4NzQ3NiwiaXNzIjoiRXhhbXBsZSBDb21wYW55LCBMTEMifQ.BcfVGaT_0up7wTgOhXDl49RTCQeydDnPt_r8XUJjADLxGXDoLCjuxwb5_fBb1EKQZPSz6TAwgYiOcfdXFLxglw"
+    -H "x-api-key: <%= config[:api_key] %>" \
+    -H "tio-auth-token: <%= config[:api_token] %>"
 ```
 
 <aside class="notice">
-  <br>
-  Remember to substitute "<%= config[:base_url] %>" for the Tuition.io API<br>
-  You must replace <code>xNTE2MjM5MDI</code> with your API key.<br>
-  Send the authentication token (JWT) you generate and sign with your secret in the "tio-auth-token" header.
+  <p>Remember to substitute <code><%= config[:base_url] %></code> for the Tuition.io API.</p>
+  <p>You must replace <code><%= config[:api_key] %></code> with your API key.</p>
+  <p>Send the authentication token (JWT) you generate and sign with your secret in the "tio-auth-token" header.</p>
 </aside>
 
-## Authentication Errors
-
-The Tuition.io API will report the following errors when there is a problem with the provided API Key or authentication token.
-
-Problem | Status | Message | Description
-------- | ----------- | ------- | ------------
-Invalid Signature | 403 | "Invalid JWT token. Make sure algorithm and JWT secret match." | The authentication token does not appear to be "signed" with the correct API Key secret.
-Issued At (`iat`) Invalid | 403 | 'The token does not have a valid "issued at" time.' | The token's `iat` timestamp is missing, more than 1 year in the past, or set in the future.
-Expired Token | 401 | "The token has expired." | The token's `exp` timestamp is missing or has passed.
-Wrong Encoding Algorithm | 403 | "Invalid JWT token. Make sure algorithm and JWT secret match." | The token should be encoded with `HS512`. Other encoding strategies will fail.
-Missing Token | 400 | "Missing Authentication Token" | The `tio-auth-token` was not set in the request headers.
-Missing / Invalid API Key | 400 | "Invalid API Key" | The `x-api-key` header was not sent or contains an invalid / inactive value.
-
+<%= partial "includes/authentication/errors.md.erb" %>

--- a/source/includes/authentication/examples/token/_ruby.md.erb
+++ b/source/includes/authentication/examples/token/_ruby.md.erb
@@ -1,0 +1,11 @@
+```ruby
+# Using the Ruby JWT Gem: [https://github.com/jwt/ruby-jwt]
+
+claims = {
+  iat: 1609883853, # required
+  exp: 1609887476, # required
+  iss: 'Example Company, LLC' # optional
+}
+
+token = JWT.encode(claims, '<%= config[:api_secret] %>', 'HS512')
+```

--- a/source/includes/authentication/examples/token/_shell.md.erb
+++ b/source/includes/authentication/examples/token/_shell.md.erb
@@ -1,0 +1,10 @@
+```shell
+#!/usr/bin/env bash
+jwt_header=$(echo -n '{"alg":"HS512"}' | base64 | sed s/\+/-/g | sed 's/\//_/g' | sed -E s/=+$//)
+payload=$(echo -n '{"iat":1609883853,"exp":1609887476,"iss":"Example Company, LLC"}' | base64 | sed s/\+/-/g |sed 's/\//_/g' |  sed -E s/=+$//)
+secret='<%= config[:api_secret] %>'
+hmac_signature=$(echo -n "${jwt_header}.${payload}" |  openssl sha512 -hmac "$secret" -binary | base64 | sed s/\+/-/g | sed 's/\//_/g' | sed -E s/=+$//)
+jwt="${jwt_header}.${payload}.${hmac_signature}"
+
+echo ${jwt}
+```

--- a/source/includes/companies/_associations.md.erb
+++ b/source/includes/companies/_associations.md.erb
@@ -1,0 +1,6 @@
+### Associations
+
+Association | One / Many   |  Description
+----------  | ------------ | -------------
+`employees` | Many         | List of employees associated to the company
+`plans`     | Many         | List of contribution plans associated to the company

--- a/source/includes/companies/_attributes.md.erb
+++ b/source/includes/companies/_attributes.md.erb
@@ -1,0 +1,5 @@
+### Attributes
+
+Attribute | Description
+----------| -------------
+`name`    | The name of the company.

--- a/source/includes/companies/_index.md.erb
+++ b/source/includes/companies/_index.md.erb
@@ -1,0 +1,75 @@
+# Companies
+
+## List Companies
+
+```shell
+## Request Companies
+curl "<%= config[:base_url] %>/companies" \
+     -H 'x-api-key: <%= config[:api_key] %>' \
+     -H 'tio-auth-token: <%= config[:api_token] %>'
+```
+
+> The above request returns JSON structured like this:
+
+```json
+{
+  "data": [
+    {
+      "id": "1337",
+      "type": "companies",
+      "attributes": {
+        "name": "Cat Co."
+      }
+    }
+  ],
+  "meta": {
+    "page": {
+      "total": 1
+    },
+    "requester": 14,
+    "copyright": "©2021"
+  }
+}
+```
+
+### HTTP Request
+
+`GET <%= config[:base_url]%>/companies`
+
+<%= partial "includes/companies/attributes.md.erb" %>
+<%= partial "includes/companies/associations.md.erb" %>
+
+## Show Company
+
+```shell
+## Request Company
+curl "<%= config[:base_url] %>/companies/1337" \
+     -H 'x-api-key: <%= config[:api_key] %>' \
+     -H 'tio-auth-token: <%= config[:api_token] %>'
+```
+
+> The above request returns JSON structured like this:
+
+```json
+{
+  "data": {
+    "id": "1337",
+    "type": "companies",
+    "attributes": {
+      "name": "Cat Co."
+    }
+  },
+  "meta": {
+    "requester": 14,
+    "copyright": "©2021"
+  }
+}
+```
+
+### HTTP Request
+
+`GET <%= config[:base_url]%>/companies/<ID>`
+
+<%= partial "includes/companies/attributes.md.erb" %>
+<%= partial "includes/companies/associations.md.erb" %>
+

--- a/source/includes/employees/_index.md.erb
+++ b/source/includes/employees/_index.md.erb
@@ -4,7 +4,7 @@
 
 ```shell
 ## Request Employees
-curl "<%= config[:base_url]%>employees?page%5Blimit%5D=2" \
+curl "<%= config[:base_url] %>/employees?page%5Blimit%5D=2" \
      -H 'x-api-key: <%= config[:api_key] %>' \
      -H 'tio-auth-token: <%= config[:api_token] %>'
 ```
@@ -41,13 +41,6 @@ curl "<%= config[:base_url]%>employees?page%5Blimit%5D=2" \
 ```
 
 `GET <%= config[:base_url] %>/employees?page%5Blimit%5D=2`
-
-### Query Parameters
-
-Parameter | Default | Description
---------- | ------- | -----------
-page[limit] | 500 | If set to true, the result will also include cats.
-page[offset] | 0 | If set to false, the result will include kittens that have already been adopted.
 
 <aside class="success">
 Remember — additional information is included in the response. See relations and parameters for more info.

--- a/source/includes/jsonapi/_index.md.erb
+++ b/source/includes/jsonapi/_index.md.erb
@@ -1,0 +1,13 @@
+# JSONAPI Basics
+
+The Tuition.io API conforms to the [JSONAPI 1.0 specification](https://www.jsonapi.org).
+
+## Query Parameters
+
+Parameter     | Default   | Description
+------------- | --------- | -----------
+page[limit]   | 50        | The number of records to fetch. (Max: 200)
+page[offset]  | 0         | The index of the first record to fetch.
+include       | NONE      | A comma-separated list of association types to "side-load" in the response payload.
+sort          | id        | For listing endpoints, the attribute the API should use to sort results. Prefix with a `-` to indicate descending order.
+fields[type]  | all       | A comma-separated list of attributes to render in the JSON response

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -10,6 +10,8 @@ toc_footers:
 
 includes:
   - authentication/index.md.erb
+  - jsonapi/index.md.erb
+  - companies/index.md.erb
   - employees/index.md.erb
   - errors
 


### PR DESCRIPTION
* Consolidated Query Params summary under JSONAPI heading
* Documentation for SHOW / LIST companies
* Refactor authentication documentation to use more config

Next Steps

Fix Employee examples.
Differentiate Employee attributes and associations.
Plans documentation?
