### PR TITLE
Update employee attributes, query params

### DIFF
--- a/source/includes/employees/_attributes.md.erb
+++ b/source/includes/employees/_attributes.md.erb
@@ -3,7 +3,8 @@
 Attribute                | Type    | Description
 ------------------------ | ------- | --------------------------
 `payroll-id`             | string  | The unique payroll ID of the employee
-`is-active`              | boolean | If the employee is active (defaults to `true`)
+`is-active`              | boolean | If the employee is active (defaults to `true`) **(read-only)**
+`status`                 | string  | Participation status (Valid values are `CREATED`, `INVITED`, `PARTICIPATING`, `LEAVE_OF_ABSENCE`, `DEACTIVATED`, or `REACTIVATED`) **(read-only)**
 `first-name`             | string  | First / given name (e.g. "Calvin")
 `last-name`              | string  | Last / family name (e.g. "Broadus")
 `suffix`                 | string  | Name suffix (e.g. "Jr.")

--- a/source/includes/employees/_deactivate.md.erb
+++ b/source/includes/employees/_deactivate.md.erb
@@ -1,4 +1,4 @@
-## Deactivate a Specific Employee
+## Terminate a Specific Employee
 
 ```shell
 curl -X DELETE "<%= config[:base_url] %>/employees/<ID>" \\
@@ -6,7 +6,9 @@ curl -X DELETE "<%= config[:base_url] %>/employees/<ID>" \\
      -H 'tio-auth-token: <%= config[:api_token] %>' \\
 ```
 
-This endpoint deactivates a specific employee.
+This endpoint terminates a specific employee.
+
+Employees who have been terminated will be inactive and have status `DEACTIVATED`.
 
 ### HTTP Request
 
@@ -16,4 +18,4 @@ This endpoint deactivates a specific employee.
 
 Parameter | Description
 --------- | -----------
-ID | The ID of the employee to deactivate
+ID | The ID of the employee to terminate

--- a/source/includes/employees/_index.md.erb
+++ b/source/includes/employees/_index.md.erb
@@ -52,6 +52,7 @@ Remember — additional information is included in the response. See relations a
 <%= partial "includes/employees/create.md" %>
 <%= partial "includes/employees/update.md" %>
 <%= partial "includes/employees/deactivate.md" %>
+<%= partial "includes/employees/reinstate.md" %>
 <%= partial "includes/employees/contributions.md" %>
 
 

--- a/source/includes/employees/_index.md.erb
+++ b/source/includes/employees/_index.md.erb
@@ -46,6 +46,8 @@ curl "<%= config[:base_url] %>/employees?page%5Blimit%5D=2" \
 Remember — additional information is included in the response. See relations and parameters for more info.
 </aside>
 
+<%= partial "includes/employees/query_params.md.erb" %>
+
 <%= partial "includes/employees/request.md" %>
 <%= partial "includes/employees/create.md" %>
 <%= partial "includes/employees/update.md" %>

--- a/source/includes/employees/_reinstate.md.erb
+++ b/source/includes/employees/_reinstate.md.erb
@@ -1,0 +1,21 @@
+## Reinstate a Specific Employee
+
+```shell
+curl -X PATCH "<%= config[:base_url] %>/employees/<ID>/reinstate" \\
+     -H 'x-api-key: <%= config[:api_key] %>' \\
+     -H 'tio-auth-token: <%= config[:api_token] %>' \\
+```
+
+This endpoint reinstates a previously terminated employee.
+
+Employees who have been reinstated will be active and have status `REACTIVATED`.
+
+### HTTP Request
+
+`PATCH <%= config[:base_url]%>/employees/<ID>/reinstate`
+
+### URL Parameters
+
+Parameter | Description
+--------- | -----------
+ID | The ID of the employee to reinstate

--- a/source/includes/employees/_request.md.erb
+++ b/source/includes/employees/_request.md.erb
@@ -16,6 +16,7 @@ curl "<%= config[:base_url] %>/employees/<ID>" \\
     "attributes": {
       "payroll-id": "123ABC",
       "is-active": true,
+      "status": "CREATED",
       "first-name": "Calvin",
       "last-name": "Broadus",
       "suffix": "Jr.",


### PR DESCRIPTION
Add additional attributes to employee. Specify read-only attributes `is-active` and `status`. Add missing query params documentation to employees GET ALL documentation